### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://tenebrae.visualstudio.com/5fa019dd-d121-49fc-bfe0-b18712186444/3bd4f364-74e5-428c-bcfd-d5a9a3ead857/_apis/work/boardbadge/7719fccf-bf87-42fc-b2e7-198d3afe2bea)](https://tenebrae.visualstudio.com/5fa019dd-d121-49fc-bfe0-b18712186444/_boards/board/t/3bd4f364-74e5-428c-bcfd-d5a9a3ead857/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://tenebrae.visualstudio.com/5fa019dd-d121-49fc-bfe0-b18712186444/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.